### PR TITLE
Un 621 patch bug priority

### DIFF
--- a/src/__mocks__/database/bugs.ts
+++ b/src/__mocks__/database/bugs.ts
@@ -13,7 +13,6 @@ type BugsParams = {
   publish?: number;
   status_reason?: string;
   severity_id?: number;
-  priority_id?: number;
   created?: string;
   updated?: string;
   bug_replicability_id?: number;
@@ -69,7 +68,6 @@ class Bugs extends Table<BugsParams> {
     "publish INTEGER DEFAULT 1",
     "status_reason VARCHAR(3000)",
     "severity_id INTEGER DEFAULT 1",
-    "priority_id INTEGER DEFAULT 3",
     "created datetime NOT NULL DEFAULT CURRENT_TIMESTAMP",
     "updated datetime",
     "bug_replicability_id INTEGER",

--- a/src/__mocks__/database/bugs.ts
+++ b/src/__mocks__/database/bugs.ts
@@ -13,6 +13,7 @@ type BugsParams = {
   publish?: number;
   status_reason?: string;
   severity_id?: number;
+  priority_id?: number;
   created?: string;
   updated?: string;
   bug_replicability_id?: number;
@@ -68,6 +69,7 @@ class Bugs extends Table<BugsParams> {
     "publish INTEGER DEFAULT 1",
     "status_reason VARCHAR(3000)",
     "severity_id INTEGER DEFAULT 1",
+    "priority_id INTEGER DEFAULT 3",
     "created datetime NOT NULL DEFAULT CURRENT_TIMESTAMP",
     "updated datetime",
     "bug_replicability_id INTEGER",

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -355,6 +355,10 @@ paths:
                       required:
                         - tag_id
                         - tag_name
+                  priority:
+                    $ref: '#/components/schemas/BugPriority'
+                    x-stoplight:
+                      id: h7y0q4jv95fa9
               examples:
                 oneTagResponse:
                   value:
@@ -385,6 +389,10 @@ paths:
                         required:
                           - tag_name
                     type: object
+                priority_id:
+                  x-stoplight:
+                    id: hwme35c0ad9nd
+                  type: number
             examples:
               possibleTagEntries:
                 value:

--- a/src/routes/campaigns/campaignId/bugs/_get/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/_get/index.ts
@@ -1,5 +1,6 @@
 /** OPENAPI-CLASS: get-campaigns-cid-bugs */
 import {
+  DEFAULT_BUG_PRIORITY,
   DEFAULT_ORDER_BY_PARAMETER,
   DEFAULT_ORDER_PARAMETER,
   ERROR_MESSAGE,
@@ -17,6 +18,11 @@ interface Tag {
   tag_name: string;
 }
 
+interface Priority {
+  id: number;
+  name: string;
+}
+
 export default class BugsRoute extends CampaignRoute<{
   response: StoplightOperations["get-campaigns-cid-bugs"]["responses"]["200"]["content"]["application/json"];
   parameters: StoplightOperations["get-campaigns-cid-bugs"]["parameters"]["path"];
@@ -26,9 +32,11 @@ export default class BugsRoute extends CampaignRoute<{
   private start: number = START_QUERY_PARAM_DEFAULT;
   private order: string = DEFAULT_ORDER_PARAMETER;
   private orderBy: string = DEFAULT_ORDER_BY_PARAMETER;
+  private defaultPriority: Priority = DEFAULT_BUG_PRIORITY;
 
   private isTitleRuleActive: boolean = false;
   private tags: (Tag & { bug_id: number })[] = [];
+  private priorities: (Priority & { bug_id: number })[] = [];
   private filterBy: { [key: string]: string | string[] } | undefined;
   private filterByTags: number[] | undefined;
   private filterByNoTags: boolean = false;
@@ -100,6 +108,7 @@ export default class BugsRoute extends CampaignRoute<{
 
     if (!bugs || !bugs.length) return this.emptyResponse();
 
+    this.priorities = await this.getPriorities(bugs);
     const enhancedBugs = this.enhanceBugs(bugs);
     const filtered = this.filterBugs(enhancedBugs);
     const paginated = this.paginateBugs(filtered);
@@ -213,6 +222,26 @@ export default class BugsRoute extends CampaignRoute<{
     return bugs;
   }
 
+  private async getPriorities(bugs: Awaited<ReturnType<typeof this.getBugs>>) {
+    if (!bugs || !bugs.length) return [];
+
+    const priorities: (Priority & { bug_id: number })[] = await db.query(
+      `SELECT 
+        p.id,
+        pb.bug_id,
+        p.name
+      FROM wp_ug_priority_to_bug pb
+      JOIN wp_ug_priority p ON (pb.priority_id = p.id)
+      where pb.bug_id IN (${bugs.map((bug) => bug.id).join(",")})
+      `,
+      "tryber"
+    );
+
+    if (!priorities) return [];
+
+    return priorities;
+  }
+
   private enhanceBugs(bugs: Awaited<ReturnType<typeof this.getBugs>>) {
     if (!bugs || !bugs.length) return [];
 
@@ -227,6 +256,7 @@ export default class BugsRoute extends CampaignRoute<{
           }));
         if (!tags.length) tags = undefined;
       }
+
       return {
         ...bug,
         title: getBugTitle({
@@ -256,8 +286,8 @@ export default class BugsRoute extends CampaignRoute<{
           ...(bug.uc_prefix && { prefix: bug.uc_prefix }),
         },
         device: getBugDevice(bug),
-
         siblings: this.getSiblingsOfBug(bug, bugs),
+        priority: this.getBugPriority(bug.id),
         ...(tags && { tags }),
       };
     });
@@ -287,6 +317,18 @@ export default class BugsRoute extends CampaignRoute<{
     }
   }
 
+  private getBugPriority(bug_id: number): Priority {
+    if (!this.priorities.length) return this.defaultPriority;
+
+    const priority = this.priorities.find(
+      (priority) => priority.bug_id === bug_id
+    );
+
+    return priority
+      ? { id: priority.id, name: priority.name }
+      : this.defaultPriority;
+  }
+
   private formatBugs(bugs: ReturnType<typeof this.paginateBugs>) {
     return bugs.map((bug) => {
       return {
@@ -313,6 +355,7 @@ export default class BugsRoute extends CampaignRoute<{
         read: bug.read_status ? true : false,
         tags: bug.tags,
         siblings: bug.siblings,
+        priority: bug.priority,
       };
     });
   }

--- a/src/routes/campaigns/campaignId/bugs/_get/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/_get/index.ts
@@ -234,7 +234,7 @@ export default class BugsRoute extends CampaignRoute<{
       JOIN wp_ug_priority p ON (pb.priority_id = p.id)
       where pb.bug_id IN (${bugs.map((bug) => bug.id).join(",")})
       `,
-      "tryber"
+      "unguess"
     );
 
     if (!priorities) return [];

--- a/src/routes/campaigns/campaignId/bugs/_get/priorities.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/_get/priorities.spec.ts
@@ -1,0 +1,260 @@
+import app from "@src/app";
+import request from "supertest";
+import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
+import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
+import bugs, { BugsParams } from "@src/__mocks__/database/bugs";
+import bugMedia from "@src/__mocks__/database/bug_media";
+import bugSeverity from "@src/__mocks__/database/bug_severity";
+import bugReplicability from "@src/__mocks__/database/bug_replicability";
+import bugType from "@src/__mocks__/database/bug_type";
+import bugStatus from "@src/__mocks__/database/bug_status";
+import CampaignMeta from "@src/__mocks__/database/campaign_meta";
+import devices, { DeviceParams } from "@src/__mocks__/database/device";
+import bugsReadStatus from "@src/__mocks__/database/bug_read_status";
+import bugPriorities, {
+  BugPriorityParams,
+} from "@src/__mocks__/database/bug_priority";
+import priorities from "@src/__mocks__/database/priority";
+import useCases from "@src/__mocks__/database/use_cases";
+
+const customer_1 = {
+  id: 999,
+  company: "Company 999",
+  company_logo: "logo999.png",
+  tokens: 100,
+};
+
+const user_to_customer_1 = {
+  wp_user_id: 1,
+  customer_id: 999,
+};
+
+const project_1 = {
+  id: 999,
+  display_name: "Project 999",
+  customer_id: 999,
+};
+
+const user_to_project_1 = {
+  wp_user_id: 1,
+  project_id: 999,
+};
+
+const campaign_type_1 = {
+  id: 999,
+  name: "Functional Testing (Bug Hunting)",
+  type: FUNCTIONAL_CAMPAIGN_TYPE_ID,
+};
+
+const campaign_1 = {
+  id: 1,
+  start_date: "2017-07-20 10:00:00",
+  end_date: "2017-07-20 10:00:00",
+  close_date: "2017-07-20 10:00:00",
+  title: "Campaign 2 title",
+  customer_title: "Campaign 2 customer title",
+  status_id: 1,
+  is_public: 1,
+  campaign_type_id: campaign_type_1.id,
+  campaign_type: -1,
+  project_id: project_1.id,
+  base_bug_internal_id: "BUG01",
+};
+
+const device_1: DeviceParams = {
+  id: 12,
+  manufacturer: "Apple",
+  model: "iPhone 13",
+  platform_id: 2,
+  id_profile: 61042,
+  os_version: "iOS 18 (18)",
+  operating_system: "iOS",
+  form_factor: "Smartphone",
+};
+
+const device_2: DeviceParams = {
+  id: 15,
+  manufacturer: "Apple",
+  model: "iPhone 11",
+  platform_id: 2,
+  id_profile: 61042,
+  os_version: "iOS 16 (16)",
+  operating_system: "iOS",
+  form_factor: "Smartphone",
+};
+
+const device_3: DeviceParams = {
+  id: 60,
+  platform_id: 8,
+  id_profile: 61042,
+  os_version: "Windows 10 April 2018 Update (17134.191)",
+  operating_system: "Windows",
+  form_factor: "PC",
+  pc_type: "Notebook",
+};
+
+const bug_1: BugsParams = {
+  id: 1,
+  internal_id: "BUG011",
+  message: "[CON-TEXT-bike] - Bug 1 super-message",
+  description: "Bug 1 description",
+  expected_result: "Bug 1 expected result",
+  current_result: "Bug 1 current result",
+  campaign_id: campaign_1.id,
+  bug_type_id: 1,
+  bug_replicability_id: 1,
+  status_id: 2,
+  status_reason: "Bug 1 status reason",
+  application_section: "Bug 1 application section",
+  note: "Bug 1 note",
+  wp_user_id: 1,
+  dev_id: device_2.id,
+  is_duplicated: 1,
+  manufacturer: device_2.manufacturer,
+  model: device_2.model,
+  os: device_2.operating_system,
+  os_version: device_2.os_version,
+  severity_id: 1,
+};
+
+const bug_2: BugsParams = {
+  id: 2,
+  internal_id: "BUG012",
+  message: "Bug 2 message orange",
+  description: "Bug 2 description",
+  expected_result: "Bug 2 expected result",
+  current_result: "Bug 2 current result",
+  campaign_id: campaign_1.id,
+  bug_type_id: 2,
+  bug_replicability_id: 3,
+  status_id: 2,
+  status_reason: "Bug 2 status reason",
+  application_section: "Bug 2 application section",
+  note: "Bug 2 note",
+  wp_user_id: 1,
+  is_favorite: 1,
+  is_duplicated: 0,
+  dev_id: device_3.id,
+  manufacturer: device_3.manufacturer,
+  model: device_3.model,
+  os: device_3.operating_system,
+  os_version: device_3.os_version,
+  severity_id: 2,
+  application_section_id: 2,
+};
+
+const bug_3: BugsParams = {
+  id: 3,
+  internal_id: "BUG013",
+  message: "Bug 3 message",
+  description: "Bug 3 description",
+  expected_result: "Bug 3 expected result",
+  current_result: "Bug 3 current result",
+  campaign_id: campaign_1.id,
+  bug_type_id: 3,
+  bug_replicability_id: 1,
+  status_id: 2,
+  status_reason: "Bug 3 status reason",
+  note: "Bug 3 note",
+  wp_user_id: 1,
+  is_favorite: 1,
+  is_duplicated: 1,
+  dev_id: device_1.id,
+  manufacturer: device_1.manufacturer,
+  model: device_1.model,
+  os: device_1.operating_system,
+  os_version: device_1.os_version,
+  severity_id: 2,
+};
+
+const bug_media_1 = {
+  id: 123,
+  bug_id: bug_1.id,
+  location: "https://example.com/bug_media_1.png",
+  type: "image",
+  uploaded: "2021-10-19 12:57:57.0",
+};
+
+const bug_1_highest_priority: BugPriorityParams = {
+  bug_id: bug_1.id,
+  priority_id: 5,
+};
+const bug_2_lowest_priority: BugPriorityParams = {
+  bug_id: bug_2.id,
+  priority_id: 1,
+};
+
+describe("GET /campaigns/{cid}/bugs", () => {
+  beforeAll(async () => {
+    try {
+      await dbAdapter.add({
+        companies: [customer_1],
+        userToCustomers: [user_to_customer_1],
+        projects: [project_1],
+        userToProjects: [user_to_project_1],
+        campaignTypes: [campaign_type_1],
+        campaigns: [campaign_1],
+      });
+      await CampaignMeta.insert({
+        meta_id: 1,
+        campaign_id: campaign_1.id,
+        meta_key: "bug_title_rule",
+        meta_value: "1",
+      });
+
+      await bugs.insert(bug_1);
+      await bugs.insert(bug_2);
+      await bugs.insert(bug_3);
+
+      await bugMedia.insert(bug_media_1);
+      await bugSeverity.addDefaultItems();
+      await bugReplicability.addDefaultItems();
+      await bugType.addDefaultItems();
+      await bugStatus.addDefaultItems();
+      await priorities.addDefaultItems();
+      await devices.insert(device_1);
+      await devices.insert(device_2);
+      await devices.insert(device_3);
+
+      await bugPriorities.insert(bug_1_highest_priority);
+      await bugPriorities.insert(bug_2_lowest_priority);
+
+      await bugsReadStatus.insert({ wp_id: 1, bug_id: bug_2.id });
+      await bugsReadStatus.insert({ wp_id: 2, bug_id: bug_2.id });
+
+      await useCases.insert({ id: 1, campaign_id: campaign_1.id });
+      await useCases.insert({ id: 2, campaign_id: campaign_1.id });
+    } catch (error) {
+      console.error(error);
+    }
+  });
+
+  it("should return 200 and include priority in the list of bugs", async () => {
+    const defaultPriorities = priorities.getDefaultItems();
+
+    const bug_1_priority = defaultPriorities.find(
+      (p) => p.id === bug_1_highest_priority.priority_id
+    );
+    const bug_2_priority = defaultPriorities.find(
+      (p) => p.id === bug_2_lowest_priority.priority_id
+    );
+    const fallbackPriority = defaultPriorities.find((p) => p.name === "medium");
+
+    const response = await request(app)
+      .get(`/campaigns/${campaign_1.id}/bugs`)
+      .set("Authorization", "Bearer user");
+
+    expect(response.status).toBe(200);
+
+    expect(response.body.items.length).toEqual(3);
+    expect(response.body.items).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ priority: bug_1_priority }),
+        expect.objectContaining({ priority: bug_2_priority }),
+        expect.objectContaining({ priority: fallbackPriority }),
+      ])
+    );
+  });
+
+  // --- End of file
+});

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -1,10 +1,7 @@
 import app from "@src/app";
 import request from "supertest";
 import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
-import {
-  DEFAULT_BUG_PRIORITY,
-  FUNCTIONAL_CAMPAIGN_TYPE_ID,
-} from "@src/utils/constants";
+import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
 import bugType from "@src/__mocks__/database/bug_type";
 import bugs, { BugsParams } from "@src/__mocks__/database/bugs";
 import severities from "@src/__mocks__/database/bug_severity";

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -111,7 +111,6 @@ const bug_1: BugsParams = {
   updated: "2021-10-19 12:57:57.0",
   dev_id: device_1.id,
   severity_id: 1,
-  priority_id: 1,
   bug_replicability_id: 1,
   bug_type_id: 1,
   application_section_id: usecase_1.id,

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -111,6 +111,7 @@ const bug_1: BugsParams = {
   updated: "2021-10-19 12:57:57.0",
   dev_id: device_1.id,
   severity_id: 1,
+  priority_id: 1,
   bug_replicability_id: 1,
   bug_type_id: 1,
   application_section_id: usecase_1.id,

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -111,7 +111,6 @@ const bug_1: BugsParams = {
   updated: "2021-10-19 12:57:57.0",
   dev_id: device_1.id,
   severity_id: 1,
-  priority_id: 1,
   bug_replicability_id: 1,
   bug_type_id: 1,
   application_section_id: usecase_1.id,
@@ -212,18 +211,18 @@ const priority_3 = {
 };
 
 const bug_priority_1 = {
-  bug_id: 1,
-  priority_id: 1,
+  bug_id: bug_1.id,
+  priority_id: priority_1.id,
 };
 
 const bug_priority_2 = {
-  bug_id: 2,
-  priority_id: 3,
+  bug_id: bug_2.id,
+  priority_id: priority_2.id,
 };
 
 const bug_priority_3 = {
-  bug_id: 3,
-  priority_id: 5,
+  bug_id: bug_3.id,
+  priority_id: priority_3.id,
 }
 
 describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
@@ -368,7 +367,7 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     ).toEqual(true);
   });
 
-  // Should return bug with the default priority
+  // Should return an error 403 if the priority does not exists
   it("It should return an error 403 if the priority does not exists", async () => {
     const response = await request(app)
       .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -1,7 +1,10 @@
 import app from "@src/app";
 import request from "supertest";
 import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
-import { DEFAULT_BUG_PRIORITY, FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
+import {
+  DEFAULT_BUG_PRIORITY,
+  FUNCTIONAL_CAMPAIGN_TYPE_ID,
+} from "@src/utils/constants";
 import bugType from "@src/__mocks__/database/bug_type";
 import bugs, { BugsParams } from "@src/__mocks__/database/bugs";
 import severities from "@src/__mocks__/database/bug_severity";
@@ -223,7 +226,7 @@ const bug_priority_2 = {
 const bug_priority_3 = {
   bug_id: bug_3.id,
   priority_id: priority_3.id,
-}
+};
 
 describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
   beforeAll(async () => {
@@ -377,6 +380,16 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     expect(response.status).toBe(403);
   });
 
+  // Should return an error 400 if the priority is not a number
+  it("It should return an error 400 if the priority is not a number", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({ priority_id: "not a number" });
+
+    expect(response.status).toBe(400);
+  });
+
   // It should return the updated priority
   it("It should return the updated priority", async () => {
     const response = await request(app)
@@ -385,9 +398,24 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
       .send({ priority_id: bug_priority_1.priority_id });
 
     expect(response.status).toBe(200);
-    expect(response.body.priority).toEqual(
-      expect.objectContaining(priority_1),
-    );
+    expect(response.body.priority).toEqual(expect.objectContaining(priority_1));
+  });
+
+  // It should not return the priority if not sent
+  it("It should not return the priority if not sent", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({
+        tags: [
+          { tag_id: tag_3.tag_id },
+          { tag_name: "Tag to be add" },
+          { tag_id: tag_3.tag_id },
+        ],
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.body.priority).toBeUndefined();
   });
 
   // --- End of file

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -1,7 +1,7 @@
 import app from "@src/app";
 import request from "supertest";
 import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
-import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
+import { DEFAULT_BUG_PRIORITY, FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
 import bugType from "@src/__mocks__/database/bug_type";
 import bugs, { BugsParams } from "@src/__mocks__/database/bugs";
 import severities from "@src/__mocks__/database/bug_severity";
@@ -10,6 +10,8 @@ import statuses from "@src/__mocks__/database/bug_status";
 import devices, { DeviceParams } from "@src/__mocks__/database/device";
 import usecases, { UseCaseParams } from "@src/__mocks__/database/use_cases";
 import tags from "@src/__mocks__/database/bug_tags";
+import bug_priorities from "@src/__mocks__/database/bug_priority";
+import priorities from "@src/__mocks__/database/priority";
 
 const campaign_type_1 = {
   id: 1,
@@ -109,6 +111,7 @@ const bug_1: BugsParams = {
   updated: "2021-10-19 12:57:57.0",
   dev_id: device_1.id,
   severity_id: 1,
+  priority_id: 1,
   bug_replicability_id: 1,
   bug_type_id: 1,
   application_section_id: usecase_1.id,
@@ -193,6 +196,36 @@ const tag_3 = {
   bug_id: bug_3.id,
 };
 
+const priority_1 = {
+  id: 1,
+  name: "lowest",
+};
+
+const priority_2 = {
+  id: 3,
+  name: "medium",
+};
+
+const priority_3 = {
+  id: 5,
+  name: "highest",
+};
+
+const bug_priority_1 = {
+  bug_id: 1,
+  priority_id: 1,
+};
+
+const bug_priority_2 = {
+  bug_id: 2,
+  priority_id: 3,
+};
+
+const bug_priority_3 = {
+  bug_id: 3,
+  priority_id: 5,
+}
+
 describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
   beforeAll(async () => {
     await dbAdapter.add({
@@ -214,6 +247,10 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     await tags.insert(tag_1);
     await tags.insert(tag_2_other_cp);
     await tags.insert(tag_3);
+    await bug_priorities.insert(bug_priority_1);
+    await bug_priorities.insert(bug_priority_2);
+    await bug_priorities.insert(bug_priority_3);
+    await priorities.addDefaultItems();
   });
 
   // It should answer 403 if user is not logged in
@@ -329,6 +366,29 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     expect(
       response.body.tags[0].tag_id !== response.body.tags[1].tag_id
     ).toEqual(true);
+  });
+
+  // Should return bug with the default priority
+  it("It should return an error 403 if the priority does not exists", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({ priority_id: 999 });
+
+    expect(response.status).toBe(403);
+  });
+
+  // It should return the updated priority
+  it("It should return the updated priority", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({ priority_id: bug_priority_1.priority_id });
+
+    expect(response.status).toBe(200);
+    expect(response.body.priority).toEqual(
+      expect.objectContaining(priority_1),
+    );
   });
 
   // --- End of file

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -1,5 +1,5 @@
 /** OPENAPI-CLASS: patch-campaigns-cid-bugs-bid */
-import { ERROR_MESSAGE } from "@src/utils/constants";
+import { DEFAULT_BUG_PRIORITY, ERROR_MESSAGE } from "@src/utils/constants";
 import { getCampaign } from "@src/utils/campaigns";
 import UserRoute from "@src/features/routes/UserRoute";
 import { getProjectById } from "@src/utils/projects";

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -1,5 +1,5 @@
 /** OPENAPI-CLASS: patch-campaigns-cid-bugs-bid */
-import { DEFAULT_BUG_PRIORITY, ERROR_MESSAGE } from "@src/utils/constants";
+import { ERROR_MESSAGE } from "@src/utils/constants";
 import { getCampaign } from "@src/utils/campaigns";
 import UserRoute from "@src/features/routes/UserRoute";
 import { getProjectById } from "@src/utils/projects";

--- a/src/routes/campaigns/campaignId/priorities/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/priorities/_get/index.spec.ts
@@ -122,14 +122,21 @@ describe("GET /campaigns/{cid}/priorities", () => {
   });
 
   // It should return the list of priorities
-  it("Should return the list of priorities", async () => {
+  it("Should return the list of priorities ordered by id DESC", async () => {
     const response = await request(app)
-      .get(`/campaigns/${campaign_2.id}/priorities`)
+      .get(`/campaigns/${campaign_1.id}/priorities`)
       .set("Authorization", "Bearer user");
     expect(response.status).toBe(200);
 
     const { body } = response;
 
-    expect(body).toEqual(priorities.getDefaultItems());
+    expect(body).toEqual(priorities.getDefaultItems().sort((t1, t2) => t2.id - t1.id));
+  });
+
+  it("Should not return the list of priorities for a campaign where the user is not an owner", async () => {
+    const response = await request(app)
+      .get(`/campaigns/${campaign_2.id}/priorities`)
+      .set("Authorization", "Bearer user");
+    expect(response.status).toBe(403);
   });
 });

--- a/src/routes/campaigns/campaignId/priorities/_get/index.ts
+++ b/src/routes/campaigns/campaignId/priorities/_get/index.ts
@@ -10,9 +10,17 @@ export default class Route extends CampaignRoute<{
 
   protected async init(): Promise<void> {
     await super.init();
+    this.priorities = await db.query(
+      "SELECT id, name FROM wp_ug_priority ORDER BY id"
+    );
   }
 
-  protected async prepare(): Promise<void> {}
+  protected async prepare(): Promise<void> {
+    
+    return this.setSuccess(200, this.priorities);
+  }
 
-  private async getCampaignPriorities() {}
+  private async getCampaignPriorities() {
+    
+  }
 }

--- a/src/routes/campaigns/campaignId/priorities/_get/index.ts
+++ b/src/routes/campaigns/campaignId/priorities/_get/index.ts
@@ -11,16 +11,12 @@ export default class Route extends CampaignRoute<{
   protected async init(): Promise<void> {
     await super.init();
     this.priorities = await db.query(
-      "SELECT id, name FROM wp_ug_priority ORDER BY id"
+      "SELECT id, name FROM wp_ug_priority ORDER BY id DESC", 
+      "unguess"
     );
   }
 
   protected async prepare(): Promise<void> {
-    
     return this.setSuccess(200, this.priorities);
-  }
-
-  private async getCampaignPriorities() {
-    
   }
 }

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -1046,6 +1046,7 @@ export interface operations {
               tag_id: number;
               tag_name: string;
             }[];
+            priority?: components["schemas"]["BugPriority"];
           };
         };
       };
@@ -1061,6 +1062,7 @@ export interface operations {
                 tag_name: string;
               }
           )[];
+          priority_id?: number;
         };
       };
     };

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -11,6 +11,10 @@ export const FUNCTIONAL_CAMPAIGN_TYPE_ID = 0;
 export const EXPERIENTIAL_CAMPAIGN_TYPE_ID = 1;
 export const DEFAULT_ORDER_PARAMETER = "DESC";
 export const DEFAULT_ORDER_BY_PARAMETER = "id";
+export const DEFAULT_BUG_PRIORITY = {
+  id: 3,
+  name: "medium",
+};
 
 export const DEFAULT_EXPRESS_COST = 1;
 


### PR DESCRIPTION
Feats:
Created patch bug priority endpoint which requires a ptiority_id in the body and returns a priority, if there is no priority_id it only patches the tags. If a bug_id already exists in the wp_ug_priority_to_bug table, it updates the priority_id otherwise creates a new touple with bug_id and priority_id.

Tests:
- Checks if there is no priority_id present in request body
- Checks if user logged in
- Checks if campaign exists
- Checks a valid bug
- Checks if a priority is returned
- Checks if a priority_id exists!