### PR TITLE
Un 689 filter by priority

### DIFF
--- a/src/routes/campaigns/campaignId/bugs/_get/filters.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/_get/filters.spec.ts
@@ -277,6 +277,7 @@ const tag_1 = {
   campaign_id: campaign_1.id,
   bug_id: bug_1.id,
 };
+
 const tag_2 = {
   id: 2,
   tag_id: 1,
@@ -284,6 +285,7 @@ const tag_2 = {
   campaign_id: campaign_1.id,
   bug_id: bug_2.id,
 };
+
 const tag_4 = {
   id: 4,
   tag_id: 3,
@@ -373,6 +375,7 @@ describe("GET /campaigns/{cid}/bugs", () => {
       })
     );
   });
+
   it("Should return only read bugs if filterBy has read filter as true", async () => {
     const response = await request(app)
       .get(`/campaigns/${campaign_1.id}/bugs?filterBy[read]=true`)
@@ -412,6 +415,7 @@ describe("GET /campaigns/{cid}/bugs", () => {
       ])
     );
   });
+
   it("Should return bugs filtered by tags ignoring invalid tags", async () => {
     const response = await request(app)
       .get(`/campaigns/${campaign_1.id}/bugs?filterBy[tags]=1,3,pippo`)
@@ -442,6 +446,7 @@ describe("GET /campaigns/{cid}/bugs", () => {
       ])
     );
   });
+  
   it("Should return bugs filtered by notags", async () => {
     const response = await request(app)
       .get(`/campaigns/${campaign_1.id}/bugs?filterBy[tags]=none`)

--- a/src/routes/campaigns/campaignId/bugs/_get/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/_get/index.ts
@@ -368,6 +368,7 @@ export default class BugsRoute extends CampaignRoute<{
       if (this.filterBugsByDuplicateStatus(bug) === false) return false;
       if (this.filterBugsByTags(bug) === false) return false;
       if (this.filterBugsBySeverity(bug) === false) return false;
+      if (this.filterBugsByPriority(bug) === false) return false;
       if (this.filterBugsByReplicability(bug) === false) return false;
       if (this.filterBugsByType(bug) === false) return false;
       if (this.filterBugsByUsecase(bug) === false) return false;
@@ -466,6 +467,22 @@ export default class BugsRoute extends CampaignRoute<{
       .filter((sevId) => sevId > 0);
 
     return severitiesToFilter.includes(bug.severity.id);
+  }
+
+  private filterBugsByPriority(
+    bug: Parameters<typeof this.filterBugs>[0][number]
+  ) {
+
+    if (!this.filterBy) return true;
+    if (!this.filterBy["priorities"]) return true;
+    if (typeof this.filterBy["priorities"] !== "string") return true;
+
+    const prioritiesToFilter = this.filterBy["priorities"]
+      .split(",")
+      .map((priorityId) => (parseInt(priorityId) > 0 ? parseInt(priorityId) : 0))
+      .filter((priorityId) => priorityId > 0);
+      
+    return prioritiesToFilter.includes(bug.priority.id);
   }
 
   private filterBugsByType(bug: Parameters<typeof this.filterBugs>[0][number]) {


### PR DESCRIPTION
Feature:
1. Filter bug(s) by priority/priorities.

Tests:
1. Checking response If there are single/multiple filters on priority.
2. If a requested priority id does not exists, it will send an empty array as a response. StatusCode: 200.
3. If a non existing priority id is one of the multiple filters, it will send a response with list of bugs only with the existing filters. StatusCode: 200.
4. If the filter on priority is empty, it will send all bugs as response.