### PR TITLE
UN-915-create-campaigns-permissions-relations

### DIFF
--- a/src/__mocks__/database/companyAdapter.ts
+++ b/src/__mocks__/database/companyAdapter.ts
@@ -19,6 +19,11 @@ import UserToCustomer, {
   data as userToCustomerData,
 } from "./user_to_customer";
 
+import UserToCampaign, {
+  UserToCampaignParams,
+  data as userToCampaignData,
+} from "./user_to_campaign";
+
 import { table as featuresTable, data as featuresData } from "./features";
 
 import {
@@ -81,6 +86,7 @@ interface dataObject {
   campaignTypes?: Array<any>;
   userToProjects?: Array<UserToProjectParams>;
   userToCustomers?: Array<UserToCustomerParams>;
+  userToCampaigns?: Array<UserToCampaignParams>;
   userToFeatures?: Array<any>;
   features?: Array<any>;
   users?: Array<any>;
@@ -99,6 +105,7 @@ export const adapter = {
     await Campaigns.mock();
     await campaignTypeTable.create();
     await UserToCustomer.mock();
+    await UserToCampaign.mock();
     await UserToProjects.mock();
     await userTable.create();
     await userTableUG.create();
@@ -157,6 +164,7 @@ export const adapter = {
     await Campaigns.dropMock();
     await campaignTypeTable.drop();
     await UserToCustomer.dropMock();
+    await UserToCampaign.dropMock();
     await UserToProjects.dropMock();
     await userTable.drop();
     await userTableUG.drop();
@@ -217,6 +225,7 @@ export const adapter = {
     await Campaigns.clear();
     await campaignTypeTable.clear();
     await UserToCustomer.clear();
+    await UserToCampaign.clear();
     await UserToProjects.clear();
     await userTable.clear();
     await userTableUG.clear();
@@ -286,6 +295,12 @@ export const adapter = {
       wp_user_id: wp_user_id,
       customer_id: customer_id,
     });
+
+    await UserToCampaign.insert({
+      wp_user_id: wp_user_id,
+      campaign_id: customer_id,
+    });
+
     await UserToProjects.insert({
       wp_user_id: wp_user_id,
       project_id: project_id,
@@ -300,6 +315,7 @@ export const adapter = {
     campaignTypes = [],
     userToProjects = [],
     userToCustomers = [],
+    userToCampaigns = [],
     userToFeatures = [],
     features = [],
     users = [],
@@ -341,6 +357,11 @@ export const adapter = {
     userToCustomers.length &&
       userToCustomers.forEach(async (userToCustomer) => {
         await userToCustomerData.basicItem(userToCustomer);
+      });
+
+    userToCampaigns.length &&
+      userToCampaigns.forEach(async (userToCampaign) => {
+        await userToCampaignData.basicItem(userToCampaign);
       });
 
     const usersList = [...defaultUsers, ...users];

--- a/src/__mocks__/database/user_to_campaign.ts
+++ b/src/__mocks__/database/user_to_campaign.ts
@@ -1,0 +1,30 @@
+import Table from "./tryber_table";
+
+type UserToCampaignParams = {
+  wp_user_id?: number;
+  campaign_id?: number;
+};
+const defaultItem: UserToCampaignParams = {
+  wp_user_id: 1,
+  campaign_id: 1,
+};
+
+class UserToCampaigns extends Table<UserToCampaignParams> {
+  protected name = "wp_appq_user_to_campaign";
+  protected columns = ["wp_user_id int(11)", "campaign_id int(11)"];
+  constructor() {
+    super(defaultItem);
+  }
+}
+const userToCampaigns = new UserToCampaigns();
+export default userToCampaigns;
+export type { UserToCampaignParams };
+
+// Backward compatibility
+const data = {
+  basicItem: async (params: UserToCampaignParams) => {
+    return await userToCampaigns.insert(params);
+  },
+};
+
+export { data };

--- a/src/features/routes/CampaignRoute.ts
+++ b/src/features/routes/CampaignRoute.ts
@@ -2,6 +2,7 @@ import UserRoute from "./UserRoute";
 import * as db from "@src/features/db";
 import { getProjectById } from "@src/utils/projects/getProjectById";
 import { getTitleRule } from "@src/utils/campaigns/getTitleRule";
+import { getCampaign } from "@src/utils/campaigns";
 
 type CampaignRouteParameters = { cid: string };
 
@@ -25,7 +26,7 @@ export default class CampaignRoute<
 
     const params = this.getParameters();
 
-    if (!params.cid) throw new Error("Missing campaign id");
+    if (!params?.cid) throw new Error("Missing campaign id");
 
     this.cp_id = parseInt(params.cid);
   }
@@ -77,24 +78,46 @@ export default class CampaignRoute<
   protected async filter(): Promise<boolean> {
     if (!(await super.filter())) return false;
 
-    if (!(await this.hasAccessToProject())) {
-      this.setError(403, {
-        code: 400,
-        message: "Project not found",
-      } as OpenapiError);
-      return false;
-    }
+    if (!(await this.evaluateUserPermissions())) {
+      return false
+    };
 
     return true;
   }
 
-  private async hasAccessToProject() {
+  private async evaluateUserPermissions(): Promise<boolean> {
+    return (
+      await Promise.all([
+        await this.hasAccessToProject(),
+        await this.hasAccessToCampaign(),
+      ])
+    ).reduce((prev, curr) => prev && curr, true);
+  };
+
+  private async hasAccessToCampaign(): Promise<boolean> {
+    try {
+      await getCampaign({ campaignId: this.cp_id });
+    } catch (_error) {
+      this.setError(403, {
+        code: 400,
+        message: "Do not have Access to the Campaign",
+      } as OpenapiError);
+      return false;
+    }
+    return true;
+  }
+
+  private async hasAccessToProject(): Promise<boolean> {
     try {
       await getProjectById({
         projectId: this.getProjectId(),
         user: this.getUser(),
       });
-    } catch (error) {
+    } catch (_error) {
+      this.setError(403, {
+        code: 400,
+        message: "Project not found",
+      } as OpenapiError);
       return false;
     }
     return true;

--- a/src/routes/campaigns/campaignId/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/_get/index.spec.ts
@@ -15,6 +15,11 @@ const user_to_customer_1 = {
   customer_id: 999,
 };
 
+const user_to_campaign_1 = {
+  wp_user_id: 1,
+  campaign_id: 1,
+};
+
 const project_1 = {
   id: 999,
   display_name: "Project 999",
@@ -75,6 +80,7 @@ describe("GET /campaigns/{cid}", () => {
         await dbAdapter.add({
           companies: [customer_1],
           userToCustomers: [user_to_customer_1],
+          userToCampaigns: [user_to_campaign_1],
           projects: [project_1, project_2],
           userToProjects: [user_to_project_1],
           campaignTypes: [campaign_type_1],
@@ -106,12 +112,14 @@ describe("GET /campaigns/{cid}", () => {
   });
 
   // It should answer 403 if the user has no permissions to see the campaign
-  it("Should answer 403 if the user has no permissions to see the campaign", async () => {
+  it("Should answer 403 if the campaign exists but the user has no permissions to see the campaign", async () => {
     const response = await request(app)
       .get(`/campaigns/${campaign_2.id}`)
       .set("Authorization", "Bearer user");
+
     expect(response.status).toBe(403);
   });
+
 
   // It should answer 200 with the campaign
   it("Should answer 200 with the campaign", async () => {


### PR DESCRIPTION
Tests: 
- Added test to check if user has the permission to see the campaign.

Feature:
- Adding "wp_appq_user_to_campaign" table
    - Two columns: "wp_user_id int(11)", "campaign_id int(11)"
    - Default Item: {
        wp_user_id: 1,
        campaign_id: 1,
     }
- Checking for permission in all Campaign Routes. 