### PR TITLE
New-custom-status-post-patch-delete

### DIFF
--- a/src/__mocks__/database/custom_status.ts
+++ b/src/__mocks__/database/custom_status.ts
@@ -20,56 +20,80 @@ const defaultCustomStatuses = [
   {
     id: 1,
     name: "to do",
-    phase_id: 1,
+    phase: {
+      id: 1,
+      name: "working",
+    },
     color: "ffffff",
     is_default: 1,
   },
   {
     id: 2,
     name: "pending",
-    phase_id: 1,
+    phase: {
+      id: 1,
+      name: "working",
+    },
     color: "ffffff",
     is_default: 1,
   },
   {
     id: 3,
     name: "to be imported",
-    phase_id: 1,
+    phase: {
+      id: 1,
+      name: "working",
+    },
     color: "ffffff",
     is_default: 1,
   },
   {
     id: 4,
     name: "open",
-    phase_id: 1,
+    phase: {
+      id: 1,
+      name: "working",
+    },
     color: "ffffff",
     is_default: 1,
   },
   {
     id: 5,
     name: "to be retested",
-    phase_id: 1,
+    phase: {
+      id: 1,
+      name: "working",
+    },
     color: "ffffff",
     is_default: 1,
   },
   {
     id: 6,
     name: "solved",
-    phase_id: 2,
+    phase: {
+      id: 2,
+      name: "completed",
+    },
     color: "ffffff",
     is_default: 1,
   },
   {
     id: 7,
     name: "not a bug",
-    phase_id: 2,
+    phase: {
+      id: 2,
+      name: "completed",
+    },
     color: "ffffff",
     is_default: 1,
   },
   {
     id: 8,
     name: "under IT analysis",
-    phase_id: 1,
+    phase: {
+      id: 1,
+      name: "working",
+    },
     color: "ffffff",
     is_default: 1,
   },
@@ -89,7 +113,13 @@ class CustomStatuses extends Table<CustomStatusParams> {
 
   async addDefaultItems() {
     defaultCustomStatuses.forEach(async (customStatus) => {
-      await this.insert(customStatus);
+      await this.insert({
+        id: customStatus.id,
+        name: customStatus.name,
+        phase_id: customStatus.phase.id,
+        color: customStatus.color,
+        is_default: customStatus.is_default,
+      });
     });
   }
 

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -579,29 +579,37 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/BugCustomStatus'
+                type: array
+                items:
+                  $ref: '#/components/schemas/BugCustomStatus'
               examples:
                 Example 1:
                   value:
-                    id: 1
-                    name: to do
-                    color: ffffff
-                    phase_id: 1
-                    is_default: 1
+                    - id: 10
+                      name: to be done
+                      color: ffffff
+                      phase_id: 1
+                      is_default: 0
       security:
         - JWT: []
       requestBody:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                phase_id:
-                  type: integer
-              required:
-                - name
+              type: array
+              items:
+                x-stoplight:
+                  id: a6esft9a2ipru
+                type: object
+                properties:
+                  name:
+                    type: string
+                    x-stoplight:
+                      id: mmcdwmjgz9vdp
+                  color:
+                    type: string
+                    x-stoplight:
+                      id: las7zwq9lpl86
             examples: {}
     delete:
       summary: ''
@@ -634,10 +642,70 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                custom_status_id:
-                  type: integer
+              type: array
+              items:
+                x-stoplight:
+                  id: 5s63akyn9b09g
+                type: object
+                properties:
+                  custom_status_id:
+                    type: integer
+                    x-stoplight:
+                      id: yq0xyf41j9pqy
+                required:
+                  - custom_status_id
+            examples:
+              Example 1:
+                value:
+                  - custom_status_id: 10
+    patch:
+      summary: ''
+      operationId: patch-campaigns-cid-custom_statuses
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/BugCustomStatus'
+              examples:
+                Example 1:
+                  value:
+                    - id: 10
+                      name: new name
+                      color: '000000'
+                      phase_id: 1
+                      is_default: 0
+      x-stoplight:
+        id: ctmftiuj4yrvu
+      security:
+        - JWT: []
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                x-stoplight:
+                  id: wb59fm4stpfdo
+                type: object
+                properties:
+                  custom_status_id:
+                    type: integer
+                    x-stoplight:
+                      id: wx4zzf97ag2xt
+                  name:
+                    type: string
+                    x-stoplight:
+                      id: kt5gn4vuhj4n2
+                  color:
+                    type: string
+                    x-stoplight:
+                      id: kh3lxu920v90k
+                required:
+                  - custom_status_id
   '/campaigns/{cid}/custom_statuses/{csid}':
     parameters:
       - schema:
@@ -650,37 +718,6 @@ paths:
         name: csid
         in: path
         required: true
-    patch:
-      summary: Update custom status
-      tags: []
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/BugCustomStatus'
-              examples:
-                Example 1:
-                  value:
-                    id: 1
-                    name: to do
-                    color: ffffff
-                    phase_id: 1
-                    is_default: 1
-      operationId: patch-campaigns-cid-custom_statuses-csid
-      security:
-        - JWT: []
-      requestBody:
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                name:
-                  type: string
-                color:
-                  type: string
   '/campaigns/{cid}/devices':
     parameters:
       - name: cid

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -598,18 +598,12 @@ paths:
             schema:
               type: array
               items:
-                x-stoplight:
-                  id: a6esft9a2ipru
                 type: object
                 properties:
                   name:
                     type: string
-                    x-stoplight:
-                      id: mmcdwmjgz9vdp
                   color:
                     type: string
-                    x-stoplight:
-                      id: las7zwq9lpl86
             examples: {}
     delete:
       summary: ''
@@ -644,14 +638,10 @@ paths:
             schema:
               type: array
               items:
-                x-stoplight:
-                  id: 5s63akyn9b09g
                 type: object
                 properties:
                   custom_status_id:
                     type: integer
-                    x-stoplight:
-                      id: yq0xyf41j9pqy
                 required:
                   - custom_status_id
             examples:
@@ -678,8 +668,6 @@ paths:
                       color: '000000'
                       phase_id: 1
                       is_default: 0
-      x-stoplight:
-        id: ctmftiuj4yrvu
       security:
         - JWT: []
       requestBody:
@@ -688,22 +676,14 @@ paths:
             schema:
               type: array
               items:
-                x-stoplight:
-                  id: wb59fm4stpfdo
                 type: object
                 properties:
                   custom_status_id:
                     type: integer
-                    x-stoplight:
-                      id: wx4zzf97ag2xt
                   name:
                     type: string
-                    x-stoplight:
-                      id: kt5gn4vuhj4n2
                   color:
                     type: string
-                    x-stoplight:
-                      id: kh3lxu920v90k
                 required:
                   - custom_status_id
   '/campaigns/{cid}/custom_statuses/{csid}':

--- a/src/reference/openapi.yml
+++ b/src/reference/openapi.yml
@@ -208,16 +208,18 @@ paths:
                           id: 0
                           name: string
                         priority:
-                          id: 12
-                          name: Highest
+                          id: 0
+                          name: string
                         custom_status:
-                          id: 1
-                          name: to do
-                          color: ffffff
-                          phase_id: 1
+                          id: 0
+                          name: string
+                          color: string
+                          phase:
+                            id: 0
+                            name: string
                           is_default: 0
                         created: string
-                        occurred_date: '2023-02-09T15:15:04+01:00'
+                        occurred_date: string
                         updated: string
                         note: string
                         device:
@@ -228,9 +230,9 @@ paths:
                           type: smartphone
                         application_section:
                           id: 0
-                          simple_title: string
                           prefix_title: string
                           title: string
+                          simple_title: string
                         duplicated_of_id: 0
                         is_favorite: 0
                         read: true
@@ -540,7 +542,7 @@ paths:
           type: string
         description: Campaign id
     get:
-      summary: Get Campaigns Priorities
+      summary: Get campaign Custom Statuses
       tags: []
       responses:
         '200':
@@ -554,11 +556,13 @@ paths:
               examples:
                 Example 1:
                   value:
-                    - id: 1
-                      name: to do
-                      color: ffffff
-                      phase_id: 1
-                      is_default: 1
+                    - id: 0
+                      name: string
+                      color: string
+                      phase:
+                        id: 0
+                        name: string
+                      is_default: 0
         '400':
           $ref: '#/components/responses/Error'
         '403':
@@ -585,10 +589,12 @@ paths:
               examples:
                 Example 1:
                   value:
-                    - id: 10
-                      name: to be done
-                      color: ffffff
-                      phase_id: 1
+                    - id: 0
+                      name: string
+                      color: string
+                      phase:
+                        id: 0
+                        name: string
                       is_default: 0
       security:
         - JWT: []
@@ -620,15 +626,12 @@ paths:
               examples:
                 Example 1:
                   value:
-                    - id: 1
-                      name: to do
-                      color: ffffff
-                      phase_id: 1
-                      is_default: 1
-                    - id: 2
-                      name: pending
-                      color: '000000'
-                      phase_id: 1
+                    - id: 0
+                      name: string
+                      color: string
+                      phase:
+                        id: 0
+                        name: string
                       is_default: 0
       security:
         - JWT: []
@@ -663,10 +666,12 @@ paths:
               examples:
                 Example 1:
                   value:
-                    - id: 10
-                      name: new name
-                      color: '000000'
-                      phase_id: 1
+                    - id: 0
+                      name: string
+                      color: string
+                      phase:
+                        id: 0
+                        name: string
                       is_default: 0
       security:
         - JWT: []
@@ -686,6 +691,7 @@ paths:
                     type: string
                 required:
                   - custom_status_id
+            examples: {}
   '/campaigns/{cid}/custom_statuses/{csid}':
     parameters:
       - schema:
@@ -2517,8 +2523,8 @@ components:
           type: string
         color:
           type: string
-        phase_id:
-          type: integer
+        phase:
+          $ref: '#/components/schemas/BugCustomStatusPhase'
         is_default:
           type: integer
           minimum: 0
@@ -2527,8 +2533,25 @@ components:
         - id
         - name
         - color
-        - phase_id
+        - phase
         - is_default
+    BugCustomStatusPhase:
+      title: BugCustomStatusPhase
+      x-stoplight:
+        id: 3fs23oeg8eb2w
+      type: object
+      properties:
+        id:
+          type: integer
+          x-stoplight:
+            id: j4c0htwqmpb1j
+        name:
+          type: string
+          x-stoplight:
+            id: pktyvl6o548ea
+      required:
+        - id
+        - name
     BugMedia:
       title: BugMedia
       type: object

--- a/src/routes/campaigns/campaignId/bugs/_get/customStatus.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/_get/customStatus.spec.ts
@@ -16,6 +16,7 @@ import bugCustomStatuses, {
   BugCustomStatusParams,
 } from "@src/__mocks__/database/bug_custom_status";
 import useCases from "@src/__mocks__/database/use_cases";
+import { unguess } from "@src/features/database";
 
 const customer_1 = {
   id: 999,
@@ -195,7 +196,6 @@ describe("GET /campaigns/{cid}/bugs", () => {
         userToProjects: [user_to_project_1],
         campaignTypes: [campaign_type_1],
         campaigns: [campaign_1],
-        custom_statuses: customStatuses.getDefaultItems(),
       });
 
       await CampaignMeta.insert({
@@ -232,6 +232,17 @@ describe("GET /campaigns/{cid}/bugs", () => {
       await useCases.insert({ id: 1, campaign_id: campaign_1.id });
       await useCases.insert({ id: 2, campaign_id: campaign_1.id });
 
+      await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+        id: 1,
+        name: "working",
+      });
+      await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+        id: 2,
+        name: "completed",
+      });
+
+      await customStatuses.addDefaultItems();
+
       await bugCustomStatuses.insert(bug_custom_status_2);
       await bugCustomStatuses.insert(bug_custom_status_3);
     } catch (error) {
@@ -251,6 +262,8 @@ describe("GET /campaigns/{cid}/bugs", () => {
     await bugsReadStatus.clear();
     await devices.clear();
     await useCases.clear();
+    await unguess.tables.WpUgBugCustomStatusPhase.do().delete();
+    await customStatuses.clear();
     await bugCustomStatuses.clear();
   });
 
@@ -300,7 +313,10 @@ describe("GET /campaigns/{cid}/bugs", () => {
           custom_status: expect.objectContaining({
             id: expect.any(Number),
             name: expect.any(String),
-            phase_id: expect.any(Number),
+            phase: expect.objectContaining({
+              id: expect.any(Number),
+              name: expect.any(String),
+            }),
             color: expect.any(String),
             is_default: expect.any(Number),
           }),

--- a/src/routes/campaigns/campaignId/bugs/_get/filters.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/_get/filters.spec.ts
@@ -21,6 +21,7 @@ import customStatuses from "@src/__mocks__/database/custom_status";
 import bugCustomStatuses, {
   BugCustomStatusParams,
 } from "@src/__mocks__/database/bug_custom_status";
+import { unguess } from "@src/features/database";
 
 const customer_1 = {
   id: 999,
@@ -372,6 +373,14 @@ describe("GET /campaigns/{cid}/bugs", () => {
         await useCases.insert({ id: 1, campaign_id: campaign_1.id });
         await useCases.insert({ id: 2, campaign_id: campaign_1.id });
 
+        await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+          id: 1,
+          name: "working",
+        });
+        await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+          id: 2,
+          name: "completed",
+        });
         await customStatuses.addDefaultItems();
         await bugCustomStatuses.insert(bug_customStatus_1);
         await bugCustomStatuses.insert(bug_customStatus_2);
@@ -383,6 +392,22 @@ describe("GET /campaigns/{cid}/bugs", () => {
       resolve(true);
     });
   });
+
+  afterAll(async () => {
+    await dbAdapter.clear();
+    await CampaignMeta.clear();
+    await bugs.clear();
+    await bugMedia.clear();
+    await bugSeverity.clear();
+    await bugReplicability.clear();
+    await bugType.clear();
+    await bugStatus.clear();
+    await bugsReadStatus.clear();
+    await devices.clear();
+    await useCases.clear();
+    await unguess.tables.WpUgBugCustomStatusPhase.do().delete();
+  });
+
   // Should return the normal results if the filterBy is not accepted
   it("Should ignore filterBy if is not valid", async () => {
     const response = await request(app)

--- a/src/routes/campaigns/campaignId/bugs/bugId/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_get/index.spec.ts
@@ -19,7 +19,7 @@ import bugCustomStatuses, {
 import customStatuses from "@src/__mocks__/database/custom_status";
 import useCases, { UseCaseParams } from "@src/__mocks__/database/use_cases";
 import app from "@src/app";
-import { tryber } from "@src/features/database";
+import { tryber, unguess } from "@src/features/database";
 import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
 import request from "supertest";
 
@@ -319,6 +319,15 @@ describe("GET /campaigns/{cid}/bugs/{bid}", () => {
       meta_value: "1",
     });
 
+    await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+      id: 1,
+      name: "working",
+    });
+    await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+      id: 2,
+      name: "completed",
+    });
+
     await customStatuses.addDefaultItems();
     await bugCustomStatuses.insert(bug_status_1);
     await tryber.tables.WpAppqBugReadStatus.do().insert({
@@ -344,6 +353,9 @@ describe("GET /campaigns/{cid}/bugs/{bid}", () => {
     await bugType.clear();
     await bugStatus.clear();
     await readStatus.clear();
+    await customStatuses.clear();
+    await bugCustomStatuses.clear();
+    await unguess.tables.WpUgBugCustomStatusPhase.do().delete();
   });
 
   // It should answer 403 if user is not logged in

--- a/src/routes/campaigns/campaignId/bugs/bugId/_get/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_get/index.ts
@@ -86,16 +86,38 @@ export default class Route extends BugsRoute<{
     return result[0] as { id: number; name: string };
   }
 
-  private async getCustomStatus() {
+  private async getCustomStatus(): Promise<
+    StoplightComponents["schemas"]["BugCustomStatus"]
+  > {
     const result = await db.query(
       db.format(
-        "SELECT cs.id, cs.name, cs.phase_id, cs.color, cs.is_default FROM wp_ug_bug_custom_status cs JOIN wp_ug_bug_custom_status_to_bug csb ON (csb.custom_status_id = cs.id) WHERE csb.bug_id=?",
+        `SELECT 
+          cs.id, 
+          cs.name,
+          cs.color,
+          cs.is_default,
+          csp.id as phase_id,
+          csp.name as phase_name
+        FROM wp_ug_bug_custom_status cs 
+        JOIN wp_ug_bug_custom_status_to_bug csb ON (csb.custom_status_id = cs.id) 
+        JOIN wp_ug_bug_custom_status_phase csp ON (cs.phase_id = csp.id)
+        WHERE csb.bug_id=?`,
         [this.bug_id]
       ),
       "unguess"
     );
+
     if (!result.length) return DEFAULT_BUG_CUSTOM_STATUS;
-    return result[0] as StoplightComponents["schemas"]["BugCustomStatus"];
+    return {
+      id: result[0].id,
+      name: result[0].name,
+      phase: {
+        id: result[0].phase_id,
+        name: result[0].phase_name,
+      },
+      color: result[0].color,
+      is_default: result[0].is_default,
+    };
   }
 
   private async enhanceBug(bug: Bug) {

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -14,6 +14,7 @@ import bug_priorities from "@src/__mocks__/database/bug_priority";
 import priorities from "@src/__mocks__/database/priority";
 import bug_custom_statuses from "@src/__mocks__/database/bug_custom_status";
 import custom_status from "@src/__mocks__/database/custom_status";
+import { unguess } from "@src/features/database";
 
 const campaign_type_1 = {
   id: 1,
@@ -283,9 +284,33 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     await bug_priorities.insert(bug_priority_2);
     await bug_priorities.insert(bug_priority_3);
     await priorities.addDefaultItems();
+    await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+      id: 1,
+      name: "working",
+    });
+    await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+      id: 2,
+      name: "completed",
+    });
+    await custom_status.addDefaultItems();
     await bug_custom_statuses.insert(bug_status_2);
     await bug_custom_statuses.insert(bug_status_3);
-    await custom_status.addDefaultItems();
+  });
+
+  afterAll(async () => {
+    await dbAdapter.clear();
+    await bugs.clear();
+    await severities.clear();
+    await replicabilities.clear();
+    await statuses.clear();
+    await devices.clear();
+    await usecases.clear();
+    await bug_tags.clear();
+    await bug_priorities.clear();
+    await priorities.clear();
+    await custom_status.clear();
+    await bug_custom_statuses.clear();
+    await unguess.tables.WpUgBugCustomStatusPhase.do().delete();
   });
 
   // It should answer 403 if user is not logged in

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -316,10 +316,37 @@ export default class Route extends BugsRoute<{
   }
 
   private async getAllStatuses(): Promise<CustomStatus[]> {
-    return await db.query(
-      "SELECT id, name, phase_id, color, is_default FROM wp_ug_bug_custom_status ORDER BY id DESC",
+    const results: {
+      id: number;
+      name: string;
+      color: string;
+      is_default: number;
+      phase_id: number;
+      phase_name: string;
+    }[] = await db.query(
+      `SELECT 
+        cs.id, 
+        cs.name,  
+        cs.color, 
+        cs.is_default,
+        csp.id as phase_id,
+        csp.name as phase_name 
+      FROM wp_ug_bug_custom_status cs
+      JOIN wp_ug_bug_custom_status_phase csp ON (cs.phase_id = csp.id) 
+      ORDER BY cs.id DESC`,
       "unguess"
     );
+
+    return results.map((customStatus) => ({
+      id: customStatus.id,
+      name: customStatus.name,
+      color: customStatus.color,
+      is_default: customStatus.is_default,
+      phase: {
+        id: customStatus.phase_id,
+        name: customStatus.phase_name,
+      },
+    }));
   }
 
   private async checkIfBugIdExistsInBugStatus(): Promise<Boolean> {

--- a/src/routes/campaigns/campaignId/customStatuses/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/customStatuses/_get/index.spec.ts
@@ -3,6 +3,7 @@ import request from "supertest";
 import { adapter as dbAdapter } from "@src/__mocks__/database/companyAdapter";
 import { FUNCTIONAL_CAMPAIGN_TYPE_ID } from "@src/utils/constants";
 import custom_statuses from "@src/__mocks__/database/custom_status";
+import { unguess } from "@src/features/database";
 
 const campaign_type_1 = {
   id: 1,
@@ -90,7 +91,22 @@ describe("GET /campaigns/{cid}/custom_statuses", () => {
       userToProjects: [user_to_project_1],
     });
 
+    await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+      id: 1,
+      name: "working",
+    });
+    await unguess.tables.WpUgBugCustomStatusPhase.do().insert({
+      id: 2,
+      name: "completed",
+    });
+
     await custom_statuses.addDefaultItems();
+  });
+
+  afterAll(async () => {
+    await dbAdapter.clear();
+    await unguess.tables.WpUgBugCustomStatusPhase.do().delete();
+    await custom_statuses.clear();
   });
 
   // It should answer 403 if user is not logged in

--- a/src/routes/campaigns/campaignId/customStatuses/_get/index.ts
+++ b/src/routes/campaigns/campaignId/customStatuses/_get/index.ts
@@ -11,10 +11,37 @@ export default class Route extends CampaignRoute<{
 
   protected async init(): Promise<void> {
     await super.init();
-    this.customStatuses = await db.query(
-      "SELECT id, name, phase_id, color, is_default FROM wp_ug_bug_custom_status ORDER BY id DESC",
+    const results: {
+      id: number;
+      name: string;
+      color: string;
+      is_default: number;
+      phase_id: number;
+      phase_name: string;
+    }[] = await db.query(
+      `SELECT 
+        cs.id, 
+        cs.name, 
+        cs.color, 
+        cs.is_default,
+        csp.id as phase_id,
+        csp.name as phase_name
+      FROM wp_ug_bug_custom_status cs
+      JOIN wp_ug_bug_custom_status_phase csp ON (cs.phase_id = csp.id)
+      ORDER BY cs.id DESC`,
       "unguess"
     );
+
+    this.customStatuses = results.map((result) => ({
+      id: result.id,
+      name: result.name,
+      phase: {
+        id: result.phase_id,
+        name: result.phase_name,
+      },
+      color: result.color,
+      is_default: result.is_default,
+    }));
   }
 
   protected async prepare(): Promise<void> {

--- a/src/schema.ts
+++ b/src/schema.ts
@@ -424,8 +424,13 @@ export interface components {
       id: number;
       name: string;
       color: string;
-      phase_id: number;
+      phase: components["schemas"]["BugCustomStatusPhase"];
       is_default: number;
+    };
+    /** BugCustomStatusPhase */
+    BugCustomStatusPhase: {
+      id: number;
+      name: string;
     };
     /** BugMedia */
     BugMedia: {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -18,7 +18,10 @@ export const DEFAULT_BUG_CUSTOM_STATUS: StoplightComponents["schemas"]["BugCusto
   {
     id: 1,
     name: "to do",
-    phase_id: 1,
+    phase: {
+      id: 1,
+      name: "working",
+    },
     color: "ffffff",
     is_default: 1,
   };


### PR DESCRIPTION
🔧 fix(schema.ts): remove patch operation for campaigns/{cid}/custom_statuses/{csid} endpoint
🔧 fix(schema.ts): modify request body for patch-campaigns-cid-custom_statuses operation