### PR TITLE
🐛 fix(index.spec.ts): fix missing await for update custom status + return data

### DIFF
--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.spec.ts
@@ -249,6 +249,12 @@ const status_test_with_campaign = {
   campaign_id: campaign_2.id,
 };
 
+const status_10 = {
+  id: 10,
+  name: "status 10",
+  campaign_id: campaign_1.id,
+};
+
 const bug_status_2 = {
   bug_id: bug_2.id,
   custom_status_id: status_to_be_imported.id,
@@ -300,6 +306,7 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
     });
     await custom_status.addDefaultItems();
     await custom_status.insert(status_test_with_campaign);
+    await custom_status.insert(status_10);
     await bug_custom_statuses.insert(bug_status_2);
     await bug_custom_statuses.insert(bug_status_3);
   });
@@ -594,6 +601,16 @@ describe("PATCH /campaigns/{cid}/bugs/{bid}", () => {
 
     expect(response.status).toBe(200);
     expect(response.body).toEqual({});
+  });
+
+  // It shouldn't throw an error if the body is a non default custom_status_id
+  it("It shouldn't throw an error if the body is a non default custom_status_id", async () => {
+    const response = await request(app)
+      .patch(`/campaigns/${campaign_1.id}/bugs/${bug_1.id}`)
+      .set("Authorization", "Bearer user")
+      .send({ custom_status_id: status_10.id });
+
+    expect(response.status).toBe(200);
   });
 
   // --- End of file

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -116,7 +116,7 @@ export default class Route extends BugsRoute<{
           return this.setError(403, {} as OpenapiError);
         default:
           return this.setError(500, {
-            message: "Something went wrong! Unable to update data",
+            message: error,
           } as OpenapiError);
       }
     }

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -5,6 +5,7 @@ import BugsRoute from "@src/features/routes/BugRoute";
 import { getProjectById } from "@src/utils/projects";
 import { getBugById } from "@src/utils/bugs";
 import * as db from "@src/features/db";
+import { unguess } from "@src/features/database";
 
 type AcceptedField = "tags" | "priority_id" | "custom_status_id";
 type Priority =
@@ -316,32 +317,32 @@ export default class Route extends BugsRoute<{
   }
 
   private async getAllStatuses(): Promise<CustomStatus[]> {
-    const results: {
-      id: number;
-      name: string;
-      color: string;
-      is_default: number;
-      phase_id: number;
-      phase_name: string;
-    }[] = await db.query(
-      db.format(
-        `SELECT 
-        cs.id, 
-        cs.name,  
-        cs.color, 
-        cs.is_default,
-        csp.id as phase_id,
-        csp.name as phase_name 
-    FROM wp_ug_bug_custom_status cs
-    JOIN wp_ug_bug_custom_status_phase csp ON cs.phase_id = csp.id 
-    WHERE(cs.campaign_id = ? AND cs.is_default = 0) 
-    OR (cs.campaign_id IS NULL AND cs.is_default = 1)
-    ORDER BY cs.phase_id ASC, cs.id ASC;
-    `,
-        [this.cid]
-      ),
-      "unguess"
-    );
+    const campaignId = this.cid;
+    const results = await unguess.tables.WpUgBugCustomStatus.do()
+      .select(
+        unguess.ref("id").withSchema("wp_ug_bug_custom_status"),
+        unguess.ref("name").withSchema("wp_ug_bug_custom_status"),
+        unguess.ref("color").withSchema("wp_ug_bug_custom_status"),
+        unguess.ref("is_default").withSchema("wp_ug_bug_custom_status"),
+        unguess.ref("campaign_id").withSchema("wp_ug_bug_custom_status"),
+        unguess
+          .ref("id")
+          .withSchema("wp_ug_bug_custom_status_phase")
+          .as("phase_id"),
+        unguess
+          .ref("name")
+          .withSchema("wp_ug_bug_custom_status_phase")
+          .as("phase_name")
+      )
+      .join(
+        "wp_ug_bug_custom_status_phase",
+        "wp_ug_bug_custom_status.phase_id",
+        "wp_ug_bug_custom_status_phase.id"
+      )
+      .where("campaign_id", campaignId)
+      .orWhereNull("campaign_id")
+      .orderBy("wp_ug_bug_custom_status.phase_id", "asc")
+      .orderBy("wp_ug_bug_custom_status.id", "asc");
 
     return results.map((customStatus) => ({
       id: customStatus.id,

--- a/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/bugs/bugId/_patch/index.ts
@@ -123,7 +123,10 @@ export default class Route extends BugsRoute<{
   }
 
   private async bugCustomStatusPatch() {
+    // Check if custom_status_id is in the body array
     if (!this.fields.includes("custom_status_id")) return;
+
+    // Check if the custom_status_ids exist
     const allStatuses = await this.getAllStatuses();
     const [result] = allStatuses.filter(
       (customStatus: CustomStatus) =>
@@ -131,14 +134,12 @@ export default class Route extends BugsRoute<{
     );
     if (!result) return Promise.reject("NOT_FOUND");
 
+    // Update bug status
     if (!(await this.checkIfBugIdExistsInBugStatus())) {
       await this.addStatusToBugStatus(result.id);
     } else {
-      this.updateStatusToBugStatus(result.id);
+      await this.updateStatusToBugStatus(result.id);
     }
-    const [{ custom_status_id }] = await this.getBugStatus();
-    if (custom_status_id !== this.customStatusId)
-      return Promise.reject("NOT_UPDATED");
 
     return Promise.resolve(result);
   }

--- a/src/routes/campaigns/campaignId/customStatuses/_delete/index.ts
+++ b/src/routes/campaigns/campaignId/customStatuses/_delete/index.ts
@@ -66,16 +66,8 @@ export default class Route extends CampaignRoute<{
         "wp_ug_bug_custom_status.phase_id",
         "wp_ug_bug_custom_status_phase.id"
       )
-      .where(function () {
-        this.where("wp_ug_bug_custom_status.campaign_id", campaignId)
-          .andWhere("wp_ug_bug_custom_status.is_default", 0)
-          .orWhere(function () {
-            this.whereNull("wp_ug_bug_custom_status.campaign_id").andWhere(
-              "wp_ug_bug_custom_status.is_default",
-              1
-            );
-          });
-      })
+      .where("campaign_id", campaignId)
+      .orWhereNull("campaign_id")
       .orderBy("wp_ug_bug_custom_status.phase_id", "asc")
       .orderBy("wp_ug_bug_custom_status.id", "asc");
 

--- a/src/routes/campaigns/campaignId/customStatuses/_get/index.spec.ts
+++ b/src/routes/campaigns/campaignId/customStatuses/_get/index.spec.ts
@@ -227,7 +227,19 @@ describe("GET /campaigns/{cid}/custom_statuses", () => {
         }),
       }),
       expect.objectContaining({
+        id: status_test_with_campaign_and_default_1.id,
+        phase: expect.objectContaining({
+          id: 1,
+        }),
+      }),
+      expect.objectContaining({
         id: status_test_with_campaign_and_default_2.id,
+        phase: expect.objectContaining({
+          id: 1,
+        }),
+      }),
+      expect.objectContaining({
+        id: status_test_with_campaign_and_default_3.id,
         phase: expect.objectContaining({
           id: 1,
         }),

--- a/src/routes/campaigns/campaignId/customStatuses/_get/index.ts
+++ b/src/routes/campaigns/campaignId/customStatuses/_get/index.ts
@@ -33,16 +33,8 @@ export default class Route extends CampaignRoute<{
         "=",
         "wp_ug_bug_custom_status_phase.id"
       )
-      .where(function () {
-        this.where("wp_ug_bug_custom_status.campaign_id", campaignId)
-          .andWhere("wp_ug_bug_custom_status.is_default", 0)
-          .orWhere(function () {
-            this.whereNull("wp_ug_bug_custom_status.campaign_id").andWhere(
-              "wp_ug_bug_custom_status.is_default",
-              1
-            );
-          });
-      })
+      .where("campaign_id", campaignId)
+      .orWhereNull("campaign_id")
       .orderBy("wp_ug_bug_custom_status.phase_id", "asc")
       .orderBy("wp_ug_bug_custom_status.id", "asc");
 

--- a/src/routes/campaigns/campaignId/customStatuses/_patch/index.ts
+++ b/src/routes/campaigns/campaignId/customStatuses/_patch/index.ts
@@ -84,16 +84,8 @@ export default class Route extends CampaignRoute<{
         "=",
         "wp_ug_bug_custom_status_phase.id"
       )
-      .where(function () {
-        this.where("wp_ug_bug_custom_status.campaign_id", campaignId)
-          .andWhere("wp_ug_bug_custom_status.is_default", 0)
-          .orWhere(function () {
-            this.whereNull("wp_ug_bug_custom_status.campaign_id").andWhere(
-              "wp_ug_bug_custom_status.is_default",
-              1
-            );
-          });
-      })
+      .where("campaign_id", campaignId)
+      .orWhereNull("campaign_id")
       .orderBy("wp_ug_bug_custom_status.phase_id", "asc")
       .orderBy("wp_ug_bug_custom_status.id", "asc");
 


### PR DESCRIPTION
🐛 fix(index.ts): update query to use unguess library for custom status retrieval
🐛 fix(index.spec.ts): add missing status_test_with_campaign_and_default_3 object