### PR TITLE
feat(bug-types): return custom bugTypes

### DIFF
--- a/src/routes/campaigns/campaignId/bugTypes/_get/index.ts
+++ b/src/routes/campaigns/campaignId/bugTypes/_get/index.ts
@@ -40,7 +40,7 @@ export default class Route extends CampaignRoute<{
         FROM wp_appq_evd_bug_type btype
                 JOIN wp_appq_additional_bug_types add_btype 
                   ON btype.id = add_btype.bug_type_id
-        WHERE btype.is_enabled = 1 AND add_btype.campaign_id = ?`,
+        WHERE add_btype.campaign_id = ?`,
         [this.cp_id]
       )
     );


### PR DESCRIPTION
When a custom bugType is added, it's often disable because we don't want to make it default for every new campaign. 
The bug campaignType route must return every custom bug type linked to the cp, even if it's not active. The custom bugType feature is broken by design and with this improvement can be at least used in the dashboard